### PR TITLE
Add keepass entry filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,28 @@ To access Keepass databases the KeepassHttp plugin needs to be installed.
 3. Enter `insomnia-plugin-keepass` and click "Install Plugin"
 4. Close the dialog.
 
+## Usage
+
+1. In any input field press `CTRL+Space` and select `Fetch from Keepass -> KeepassXC`
+2. For `Keepass` set `KeepassHttp URL`, for `KeepassXC` set `Path to KeepassXC application` if default values aren't correct
+3. Enter `Search URL`
+4. Select which `Entry field` to retrieve from Keepass 
+5. For `KeepassXC` make sure to enable `Browser Integration`
+6. Press `Create Database Link`, enter and confirm if KeepassXC shows popup to link database
+7. Press `Refresh ⟳` to test
+
+   _Note: The `Live Preview` will not show the secret value retrieved from Keepass, it is only used when e.g. sending in HTTP requests etc._
+    
+
 ## Filtering
 
 *Note*: **This is implemented only for KeePassXC**
 
-If you have more than one entry associated in KeePass(XC) with the same URL, the
-original plugin was just using the first entry from the list.
+If you have more than one entry associated with the `Search URL` in KeePass(XC), the first entry returned from Keepass is used.
+You can optionally filter the retrieved entries:
 
-This version allows to (optionally) filter the returned KeePass(XC) entries.
-To do so:
+1. Check `Filter entries by additional field?`
+2. Choose a predefined `Filter Field` (e.g. `Username`) or a custom `Additional Attribute`
 
-- Check `Filter entries by additional attribute?`
-- Fill in the `Attribute name (KPH:)` field.
-
-The only entries returned will be the ones that include the additional attribute
-`KPH: \<attribute field value\>`.
+    _Note: For `Additional Attribute` the attribute has to have the format: "KPH: \<VALUE\>"_
+3. Enter the `Field value` to filter by

--- a/README.md
+++ b/README.md
@@ -1,12 +1,31 @@
 # Insomnia plugin for fetching credentials from Keepass and KeepassXC
+
 Access your Keepass or KeepassXC database to fetch credentials via this custom template tag plugin.
 
-# Pre-requisites
+## Pre-requisites
+
 This plugin requires [Insomnia](https://insomnia.rest/).  
 To access Keepass databases the KeepassHttp plugin needs to be installed.
 
-# Installation
+## Installation
+
 1. Start Insomnia,
 2. Click "Preferences" and choose the "Plugins" tab,
 3. Enter `insomnia-plugin-keepass` and click "Install Plugin"
 4. Close the dialog.
+
+## Filtering
+
+*Note*: **This is implemented only for KeePassXC**
+
+If you have more than one entry associated in KeePass(XC) with the same URL, the
+original plugin was just using the first entry from the list.
+
+This version allows to (optionally) filter the returned KeePass(XC) entries.
+To do so:
+
+- Check `Filter entries by additional attribute?`
+- Fill in the `Attribute name (KPH:)` field.
+
+The only entries returned will be the ones that include the additional attribute
+`KPH: \<attribute field value\>`.

--- a/main.js
+++ b/main.js
@@ -83,6 +83,10 @@ module.exports.templateTags = [{
                     value: _C.FIELD_PASSWORD
                 }
             ]
+        },
+        {
+            type: 'string',
+            displayName: 'Filter entries by username'
         }
     ],
     actions: [
@@ -121,7 +125,7 @@ module.exports.templateTags = [{
             })
         }
     ],
-    async run (context, which, host, file, url, field) {
+    async run (context, which, host, file, url, field, filter) {
         const {store, renderPurpose} = context;
 
         host = which === _C.KEEPASS ? host || Utils.defaultHost : undefined;
@@ -138,7 +142,7 @@ module.exports.templateTags = [{
 
             await keepass.testAssociate();
 
-            const entries = await keepass.getCredentials(url);
+            const entries = await keepass.getCredentials(url, filter);
 
             if (entries.length) {
                 return entries.pop()[field] || '';
@@ -168,7 +172,7 @@ module.exports.templateTags = [{
                     throw new Error('Database link is invalid. Please try reastablish a link.');
                 }
 
-                const entries = await keepass.getCredentials(url);
+                const entries = await keepass.getCredentials(url, filter);
                 cachedResult = entries.length.toString();
 
                 await store.setItem(hash, cachedResult);

--- a/main.js
+++ b/main.js
@@ -85,8 +85,14 @@ module.exports.templateTags = [{
             ]
         },
         {
+            type: 'boolean',
+            displayName: 'Filter entries by additional attribute?',
+            defaultValue: '-'
+        },
+        {
             type: 'string',
-            displayName: 'Filter entries by username'
+            displayName: 'Attribute name (KPH:)',
+            hide: args => args[5].value !== true
         }
     ],
     actions: [
@@ -125,7 +131,7 @@ module.exports.templateTags = [{
             })
         }
     ],
-    async run (context, which, host, file, url, field, filter) {
+    async run (context, which, host, file, url, field, filter, filter_attr) {
         const {store, renderPurpose} = context;
 
         host = which === _C.KEEPASS ? host || Utils.defaultHost : undefined;
@@ -142,7 +148,7 @@ module.exports.templateTags = [{
 
             await keepass.testAssociate();
 
-            const entries = await keepass.getCredentials(url, filter);
+            entries = await keepass.getCredentials(url, filter, filter_attr);
 
             if (entries.length) {
                 return entries.pop()[field] || '';
@@ -159,7 +165,7 @@ module.exports.templateTags = [{
             refreshButton.addEventListener('click', onRefresh);
         }
 
-        const hash = createHash('MD5').update(JSON.stringify({which, host, file, url, field})).digest('hex');
+        const hash = createHash('MD5').update(JSON.stringify({which, host, file, url, field, filter_attr})).digest('hex');
         let cachedResult = await store.getItem(hash);
 
         if (cachedResult === null) {
@@ -172,7 +178,7 @@ module.exports.templateTags = [{
                     throw new Error('Database link is invalid. Please try reastablish a link.');
                 }
 
-                const entries = await keepass.getCredentials(url, filter);
+                entries = await keepass.getCredentials(url, filter, filter_attr);
                 cachedResult = entries.length.toString();
 
                 await store.setItem(hash, cachedResult);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "insomnia-plugin-keepass",
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {

--- a/src/KeepassXC.js
+++ b/src/KeepassXC.js
@@ -106,16 +106,17 @@ class KeepassXC
 
     /**
      * @param {string|URL} url
-     * @param {string} filter
+     * @param {boolean} filter
+     * @param {string} filter_attr
      * @returns {Promise<null|[]>}
      */
-    async getCredentials (url, filter)
+    async getCredentials (url, filter, filter_attr)
     {
         try {
             this._client.connect();
 
-            function filterLogin(entry) {
-                return entry['login'] == filter;
+            function filterAttr(entry) {
+                return entry['stringFields'].some(f => JSON.stringify(f).includes(filter_attr));
             }
 
             if (!await this._verifyKeys()) {
@@ -128,7 +129,7 @@ class KeepassXC
             });
 
             if (filter) {
-                return response.entries.filter(filterLogin);
+                return response.entries.filter(filterAttr);
             }
 
             return response.entries;

--- a/src/KeepassXC.js
+++ b/src/KeepassXC.js
@@ -107,16 +107,22 @@ class KeepassXC
     /**
      * @param {string|URL} url
      * @param {boolean} filter
-     * @param {string} filter_attr
+     * @param {string} filter_key
+     * @param {string} filter_value
      * @returns {Promise<null|[]>}
      */
-    async getCredentials (url, filter, filter_attr)
+    async getCredentials (url, filter, filter_key, filter_value)
     {
         try {
             this._client.connect();
 
             function filterAttr(entry) {
-                return entry['stringFields'].some(f => JSON.stringify(f).includes(filter_attr));
+                const value = entry[filter_key];
+                if (Array.isArray(value)) {
+                    return value.some(f => JSON.stringify(f).includes(filter_value));
+                } else {
+                    return value === filter_value;
+                }
             }
 
             if (!await this._verifyKeys()) {

--- a/src/KeepassXC.js
+++ b/src/KeepassXC.js
@@ -72,7 +72,7 @@ class KeepassXC
 
             return this._association;
         } catch (err) {
-             return Promise.reject(new Error(`Associate request failed: ${response.error}`));
+            return Promise.reject(new Error(`Associate request failed: ${response.error}`));
         } finally {
             this._client.disconnect();
         }
@@ -106,12 +106,17 @@ class KeepassXC
 
     /**
      * @param {string|URL} url
+     * @param {string} filter
      * @returns {Promise<null|[]>}
      */
-    async getCredentials (url)
+    async getCredentials (url, filter)
     {
         try {
             this._client.connect();
+
+            function filterLogin(entry) {
+                return entry['login'] == filter;
+            }
 
             if (!await this._verifyKeys()) {
                 return [];
@@ -121,6 +126,10 @@ class KeepassXC
                 url: url.toString(),
                 keys: [this._association.toJSON()]
             });
+
+            if (filter) {
+                return response.entries.filter(filterLogin);
+            }
 
             return response.entries;
         } catch (err) {

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -71,7 +71,7 @@ class Utils
     static async removeAssociation (store)
     {
         try {
-             await store.clear();
+            await store.clear();
         } catch (err) {
             throw new Error('Could not unlink database.');
         }

--- a/src/Utils.js
+++ b/src/Utils.js
@@ -6,21 +6,28 @@ const
         ASSOCIATION_KEY: 'association',
         FIELD_USERNAME: 'login',
         FIELD_PASSWORD: 'password',
+        FIELD_GROUP: 'group',
+        FIELD_ENTRY_NAME: 'name',
+        FIELD_ADDITIONAL_ATTRIBUTE: 'stringFields',
         KEEPASS: 'keepass',
         KEEPASSXC: 'keepassxc',
         DEFAULT_KEEPASSHTTP_URL: Keepass.DEFAULT_URL.toString(),
         DEFAULT_KEEPASSXC_MACOS: '/Applications/KeePassXC.app',
         MACOS_PROXY: '/Contents/MacOS/keepassxc-proxy',
+        LINUX_PROXY: '/usr/bin/keepassxc-proxy',
         KEEPASS_MAP: {
             keepass: 'Keepass',
             keepassxc: 'KeepassXC'
         },
         FIELD_MAP: {
             login: 'username',
-            password: 'password'
+            password: 'password',
+            group: 'group',
+            name: 'entry name'
         }
     },
     isMacOS = process.platform === 'darwin';
+    isLinux = process.platform.toLowerCase().startsWith('linux');
 
 class Utils
 {
@@ -31,7 +38,12 @@ class Utils
 
     static get defaultFile ()
     {
-        return isMacOS ? `${Utils.constants.DEFAULT_KEEPASSXC_MACOS}${Utils.constants.MACOS_PROXY}` : undefined;
+        if(isMacOS) {
+            return `${Utils.constants.DEFAULT_KEEPASSXC_MACOS}${Utils.constants.MACOS_PROXY}`
+        } else if(isLinux) {
+            return `${Utils.constants.LINUX_PROXY}`
+        }
+        return undefined
     }
 
     static get defaultHost ()


### PR DESCRIPTION
Thanks for creating this plugin, it makes managing local credentials a lot easier in Insomnia with Keepass

This is based on https://github.com/tleepa/insomnia-plugin-keepass

Currently the first entry for the given URL is used, but often you have multiple Keepass entries for the same URL, therefore a possiblity to filter by other fields is needed 

- Adds filter for  Additional Properties (implemented by @tleepa)
- Adds filter for Username, Entry Name, Entry Group
- Also added default `keepassxc-proxy` value for Linux